### PR TITLE
Prevent the evaluation of a null key during the DataGrid graphical update process

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/DefaultDataGridView.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/DefaultDataGridView.java
@@ -472,13 +472,13 @@ public final class DefaultDataGridView<K, V> implements DataGridView<K, V>, Data
 
         final boolean dataHasChanged = row.getData() != rowData;
         final boolean mustUpdateRowHeight = (row.extended || !row.isShown()) && rowData != row.getData();
-        final boolean selected = controller.isSelected(row.key);
 
         if (dataHasChanged) {
             row.setData(rowData);
             row.key = adapter.getKey(rowData);
         }
         row.show();
+        final boolean selected = controller.isSelected(row.key);
 
         updateRowCells(row, row.unpinnedCells, unpinnedTable.columns, selected);
         updateRowCells(row, row.pinnedCells, pinnedTable.columns, selected);
@@ -510,6 +510,7 @@ public final class DefaultDataGridView<K, V> implements DataGridView<K, V>, Data
         if (row.getAbsoluteIndex() >= result.getAbsoluteRowCount()) {
             row.hide();
             row.key = null;
+            row.data = null;
             return;
         }
         updateRow(row, getRowData(row.getRelativeIndex(), result));


### PR DESCRIPTION

It may happen that a previously hidden value needs to be shown again without any changes to the data contained. In this case, the key previously set to null is lost, and we have to ask the adapter for the original data key