### PR TITLE
[BUGFIX] Prevent listbox from retaining focus when clicking elsewhere…

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainer.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainer.java
@@ -132,8 +132,14 @@ public abstract class DropDownContainer<V, C extends DropDownContainerConfigurat
             widget.addKeyDownHandler(e -> {
                 if (!stopKeys && focused && e.getKeyCode() == PKeyCodes.ENTER.getCode()) {
                     setContainerVisible(!container.isVisible());
+                    if (!isOpen()) {
+                        focus();
+                    }
                 } else if (e.getKeyCode() == PKeyCodes.ESCAPE.getCode()) {
                     close();
+                    if (!isOpen()) {
+                        focus();
+                    }
                 } else {
                     onContainerKeyDown(e.getKeyCode());
                 }
@@ -483,7 +489,6 @@ public abstract class DropDownContainer<V, C extends DropDownContainerConfigurat
             afterContainerClose();
             final PCloseEvent event = new PCloseEvent(this);
             closeHandlers.forEach(l -> l.onClose(event));
-            focus();
         }
     }
 

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/listbox/ListBox.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/listbox/ListBox.java
@@ -744,12 +744,14 @@ public class ListBox<D> extends DropDownContainer<Collection<ListBoxItem<D>>, Li
                     //$FALL-THROUGH$ : same behavior than enter in multiLevel
                 case ESCAPE:
                     close();
+                    focus();
                     return;
                 case ENTER:
                     setStopKeys(true);
                     final ListBoxItemWidget listBoxItemWidget = itemContainer.getCurrentItemIndex();
                     if (listBoxItemWidget != null) listBoxItemWidget.select();
                     PScheduler.schedule(() -> setStopKeys(false), Duration.ofMillis(200));
+                    if (!isOpen()) focus();
                     return;
                 default:
                     return;


### PR DESCRIPTION
Each time the listBox closes, it regains focus. This is done to cover a specific keyboard navigation use case, where pressing Enter on a listBox value allows the user to still type in the search box without needing to use the mouse. 

However, regaining focus after each close is too aggressive, and the fix involves more precisely targeting the cases where focus is needed after closing.